### PR TITLE
Import axios module from github

### DIFF
--- a/scripts/deps.ts
+++ b/scripts/deps.ts
@@ -1,5 +1,5 @@
 export * as log from "https://deno.land/std@0.93.0/log/mod.ts";
 export { Bson, MongoClient } from "https://deno.land/x/mongo@v0.22.0/mod.ts";
 export { Collection } from "https://deno.land/x/mongo@v0.22.0/src/collection/mod.ts";
-import axiod from "https://deno.land/x/axiod/mod.ts";
+import axiod from "https://raw.githubusercontent.com/roonie007/axiod/master/mod.ts";
 export { axiod };

--- a/scripts/src/utils/apifootball/apiFootball.ts
+++ b/scripts/src/utils/apifootball/apiFootball.ts
@@ -17,8 +17,8 @@ export async function fetchData<T>(
     },
     params: {
       ...params,
-      season
-    }
+      season,
+    },
   };
   const res = await axiod.request(config);
   const data = (res.data as unknown) as FootballApiResponse<T>;

--- a/scripts/src/utils/apifootball/apiFootball.ts
+++ b/scripts/src/utils/apifootball/apiFootball.ts
@@ -8,17 +8,17 @@ export async function fetchData<T>(
   path: string,
   params: { [key: string]: string | number | boolean },
 ): Promise<FootballApiResponse<T>> {
-  const season = "2020";
-  const queryParameters = new URLSearchParams({
-    ...params,
-    season,
-  });
+  const season = 2020;
   const config = {
-    url: `https://v3.football.api-sports.io/${path}?${queryParameters}`,
+    url: `https://v3.football.api-sports.io/${path}`,
     method: "get" as const,
     headers: {
       "x-apisports-key": ApiSportsKey,
     },
+    params: {
+      ...params,
+      season
+    }
   };
   const res = await axiod.request(config);
   const data = (res.data as unknown) as FootballApiResponse<T>;


### PR DESCRIPTION
The latest versions of the axios module has not yet been published on the deno land registry.
The fix to handle query paramaters is already implemented but not published. To use this fix, we import the axios module from github directly.