### PR TITLE
Fix players search

### DIFF
--- a/frontend/src/lib/components/playerHandler.ts
+++ b/frontend/src/lib/components/playerHandler.ts
@@ -1,5 +1,6 @@
-import type { SortCriteria, Player } from '$lib/shared/types';
+import type { SortCriteria, Player, PlayerPosition } from '$lib/shared/types';
 import type { SelectedPlayer } from '$lib/stores/playerStore';
+import { get } from '$lib/utils/api';
 
 export type ThirdStatsToDisplay = {
   path: [string, string];
@@ -58,4 +59,23 @@ export function shouldDisableVote(
     selectedPlayers.every((_) => _.position !== 'Goalkeeper');
 
   return allPlayersSelected || hasAlreadyOneGoalkeeperSelected || noGoalkeeperSelected;
+}
+
+export async function searchPlayers(
+  positionCheckboxes: { position: PlayerPosition; checked: boolean }[],
+  currentSearchQuery: string | undefined,
+  sortBy: string | undefined
+): Promise<Player[]> {
+  const positionFilters: PlayerPosition[] = positionCheckboxes
+    .filter((_) => _.checked)
+    .map(({ position }) => position);
+
+  const searchParams = currentSearchQuery !== undefined ? { search: currentSearchQuery } : {};
+  const sortByParams = sortBy ? { sortBy: sortBy } : {};
+  const positionParams = positionFilters.length > 0 ? { positions: positionFilters } : {};
+  // @ts-ignore
+  const urlParams = new URLSearchParams({ ...searchParams, ...sortByParams, ...positionParams });
+  const response = await get(`search?${urlParams}`);
+  const results = await response.json();
+  return results;
 }

--- a/frontend/src/lib/components/playerHandler.ts
+++ b/frontend/src/lib/components/playerHandler.ts
@@ -73,8 +73,12 @@ export async function searchPlayers(
   const searchParams = currentSearchQuery !== undefined ? { search: currentSearchQuery } : {};
   const sortByParams = sortBy ? { sortBy: sortBy } : {};
   const positionParams = positionFilters.length > 0 ? { positions: positionFilters } : {};
-  // @ts-ignore
-  const urlParams = new URLSearchParams({ ...searchParams, ...sortByParams, ...positionParams });
+  const params = ({
+    ...searchParams,
+    ...sortByParams,
+    ...positionParams,
+  } as unknown) as URLSearchParams;
+  const urlParams = new URLSearchParams(params);
   const response = await get(`search?${urlParams}`);
   const results = await response.json();
   return results;

--- a/frontend/src/routes/players.svelte
+++ b/frontend/src/routes/players.svelte
@@ -38,7 +38,7 @@
   });
 
   $: (async () => {
-    if (!init) return
+    if (!init) return;
     players = await searchPlayers(positionCheckboxes, currentSearchQuery, sortBy);
     highlightStats = thirdStatsToDisplay(sortBy);
   })();

--- a/frontend/src/routes/players.svelte
+++ b/frontend/src/routes/players.svelte
@@ -1,9 +1,9 @@
 <script lang="ts" context="module">
   import type { LoadOutput } from '@sveltejs/kit/types/page';
-  import { get as getFromContextModule } from '$lib/utils/api.ts';
+  import { get } from '$lib/utils/api.ts';
 
   export async function load(): Promise<LoadOutput> {
-    const response = await getFromContextModule('players');
+    const response = await get('players');
     return {
       props: {
         players: await response.json(),
@@ -13,16 +13,17 @@
 </script>
 
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { Button, Checkbox, Search, Select, SelectItem } from 'carbon-components-svelte';
-  import { debounce } from '$lib/utils/debounce.ts';
   import { ChevronLeft20 } from 'carbon-icons-svelte';
+  import { debounce } from '$lib/utils/debounce.ts';
   import type { Player } from '$lib/shared/types.ts';
   import { SortByEnum, sortedPlayerPositionOptions } from '$lib/shared/types.ts';
+  import { thirdStatsToDisplay, searchPlayers } from '$lib/components/playerHandler.ts';
   import PlayerCard from '$lib/components/PlayerCard.svelte';
-  import { get } from '$lib/utils/api.ts';
-  import { thirdStatsToDisplay } from '../lib/components/playerHandler.ts';
 
   export let players: Player[];
+  let init = false;
   let currentSearchQuery;
   let sortBy;
   let highlightStats = thirdStatsToDisplay('appearences');
@@ -32,19 +33,13 @@
     checked: false,
   }));
 
-  $: (async () => {
-    const hasChecked = positionCheckboxes.every((_) => !_.checked);
-    if (!sortBy && currentSearchQuery === undefined && hasChecked) return;
-    const positionFilters = positionCheckboxes
-      .filter((_) => _.checked)
-      .map(({ position }) => position);
+  onMount(async () => {
+    init = true; // todo find something better to avoid trigger multiple search at init
+  });
 
-    const searchParams = currentSearchQuery !== undefined ? { search: currentSearchQuery } : {};
-    const sortByParams = sortBy ? { sortBy: sortBy } : {};
-    const positionParams = positionFilters.length > 0 ? { positions: positionFilters } : {};
-    const urlParams = new URLSearchParams({ ...searchParams, ...sortByParams, ...positionParams });
-    const response = await get(`search?${urlParams}`);
-    players = await response.json();
+  $: (async () => {
+    if (!init) return
+    players = await searchPlayers(positionCheckboxes, currentSearchQuery, sortBy);
     highlightStats = thirdStatsToDisplay(sortBy);
   })();
 


### PR DESCRIPTION
## Dev notes

There are some issues in the way the search is handled in the frontend part. We use the reactivity statement feature from Svelte.
But the reactive block is triggered too many times because the props of the component are not initialized. Then each time the prop receives its value the reactive block is triggered.
In order to avoid this, we added some logic to prevent an API call but this leads to some bugs. When filters are reset, no updates were performed.
A workaround is to use the onMount function to wait for the component to be mounted. The result is the reactive block is triggered only once when the component is mounted. This is not ideal but it fixes the filters issue. In a perfect world, we do not want to make an API call at all.